### PR TITLE
Respond to breaking changes: fix examples, fix ui package

### DIFF
--- a/examples/autotanks/battle_controller.go
+++ b/examples/autotanks/battle_controller.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/quasilyte/ge"
-	"github.com/quasilyte/ge/input"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 const harvestDelaySeconds = 5.0
@@ -89,7 +89,7 @@ var battleRules = []string{
 }
 
 type battleController struct {
-	input *input.MultiHandler
+	input *MultiHandler
 
 	config battleConfig
 
@@ -124,7 +124,7 @@ func (c *battleController) Init(scene *ge.Scene) {
 	c.battleState.HQDefeat = c.config.rules["mode.hq_siege"]
 	c.battleState.UnfairBots = c.config.rules["mode.unfair_bots"]
 
-	bg := ge.NewTiledBackground()
+	bg := ge.NewTiledBackground(scene.Context())
 	if c.battleState.MudTerrain {
 		bg.Hue = gmath.DegToRad(160)
 	}

--- a/examples/autotanks/colorutil.go
+++ b/examples/autotanks/colorutil.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"image/color"
+	"math"
+
+	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
+)
+
+func rgbaToHSL(c ge.ColorScale) (h, s, l gmath.Rad) {
+	r := float64(c.R)
+	g := float64(c.G)
+	b := float64(c.B)
+	maxVal := math.Max(math.Max(r, g), b)
+	minVal := math.Min(math.Min(r, g), b)
+	l = gmath.Rad((maxVal + minVal) / 2)
+
+	if maxVal == minVal {
+		h = 0
+		s = 0
+		return
+	}
+
+	d := maxVal - minVal
+	if l > 0.5 {
+		s = gmath.Rad(d / (2 - maxVal - minVal))
+	} else {
+		s = gmath.Rad(d / (maxVal + minVal))
+	}
+	switch maxVal {
+	case r:
+		h = gmath.Rad((g - b) / d)
+		if g < b {
+			h += 6
+		}
+	case g:
+		h = gmath.Rad((b-r)/d + 2)
+	case b:
+		h = gmath.Rad((r-g)/d + 4)
+	}
+	h /= 6
+
+	return
+}
+
+func hslToRGBA(h, s, l gmath.Rad) color.RGBA {
+	var r, g, b gmath.Rad
+	if s == 0 {
+		r, g, b = l, l, l // achromatic
+		return color.RGBA{R: uint8(r * 255), G: uint8(g * 255), B: uint8(b * 255), A: 255}
+	}
+
+	var q gmath.Rad
+	if l < 0.5 {
+		q = l * (1 + s)
+	} else {
+		q = l + s - l*s
+	}
+	p := 2*l - q
+	r = hueToRGB(p, q, h+1/3)
+	g = hueToRGB(p, q, h)
+	b = hueToRGB(p, q, h-1/3)
+
+	return color.RGBA{R: uint8(r * 255), G: uint8(g * 255), B: uint8(b * 255), A: 255}
+}
+
+func hueToRGB(p, q, t gmath.Rad) gmath.Rad {
+	if t < 0 {
+		t += 1
+	}
+	if t > 1 {
+		t -= 1
+	}
+	if t < 1/6 {
+		return p + (q-p)*6*t
+	}
+	if t < 1/2 {
+		return q
+	}
+	if t < 2/3 {
+		return p + (q-p)*(2/3-t)*6
+	}
+	return p
+}
+
+func SetHue(s *ge.Sprite, nh gmath.Rad) {
+	rgba := s.GetColorScale()
+	_, oldSat, oldLum := rgbaToHSL(rgba)
+	nr, ng, nb, _ := hslToRGBA(nh, oldSat, oldLum).RGBA()
+	s.SetColorScaleRGBA(uint8(nr), uint8(ng), uint8(nb), 255)
+}

--- a/examples/autotanks/explosion.go
+++ b/examples/autotanks/explosion.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/quasilyte/ge"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 type explosion struct {
@@ -25,7 +26,7 @@ func (e *explosion) Init(scene *ge.Scene) {
 	sprite := scene.NewSprite(ImageExplosion)
 	sprite.Pos.Base = &e.pos
 	sprite.FrameWidth = 64
-	sprite.Scale = e.Scale
+	sprite.SetScale(e.Scale, e.Scale)
 	scene.AddGraphics(sprite)
 
 	e.anim = ge.NewAnimation(sprite, -1)

--- a/examples/autotanks/game_controller.go
+++ b/examples/autotanks/game_controller.go
@@ -3,15 +3,15 @@ package main
 import (
 	"strconv"
 
-	"github.com/quasilyte/ge"
-	"github.com/quasilyte/ge/input"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 type gameController struct {
 	scene *ge.Scene
 
-	input *input.MultiHandler
+	input *MultiHandler
 
 	gameState *gameState
 	config    battleConfig

--- a/examples/autotanks/legacy_multihandler.go
+++ b/examples/autotanks/legacy_multihandler.go
@@ -1,0 +1,29 @@
+package main
+
+import "github.com/quasilyte/ge/input"
+
+type MultiHandler struct {
+	list []*input.Handler
+}
+
+func (h *MultiHandler) AddHandler(handler *input.Handler) {
+	h.list = append(h.list, handler)
+}
+
+func (h *MultiHandler) ActionIsJustPressed(action input.Action) bool {
+	for i := range h.list {
+		if h.list[i].ActionIsJustPressed(action) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *MultiHandler) ActionIsPressed(action input.Action) bool {
+	for i := range h.list {
+		if h.list[i].ActionIsPressed(action) {
+			return true
+		}
+	}
+	return false
+}

--- a/examples/autotanks/menu_controller.go
+++ b/examples/autotanks/menu_controller.go
@@ -3,13 +3,13 @@ package main
 import (
 	"os"
 
-	"github.com/quasilyte/ge"
-	"github.com/quasilyte/ge/input"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 type menuController struct {
-	input     *input.MultiHandler
+	input     *MultiHandler
 	scene     *ge.Scene
 	gameState *gameState
 

--- a/examples/autotanks/popup_build_tank.go
+++ b/examples/autotanks/popup_build_tank.go
@@ -3,8 +3,9 @@ package main
 import (
 	"strconv"
 
-	"github.com/quasilyte/ge"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 type popupBuildTank struct {
@@ -265,11 +266,11 @@ func (popup *popupBuildTank) tankDesign() tankDesign {
 
 func (popup *popupBuildTank) updateCategory() {
 	if popup.selectingTurret {
-		popup.turretName.ColorScale = ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1}
-		popup.hullName.ColorScale = ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1}
+		popup.turretName.SetColorScale(ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1})
+		popup.hullName.SetColorScale(ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1})
 	} else {
-		popup.hullName.ColorScale = ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1}
-		popup.turretName.ColorScale = ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1}
+		popup.hullName.SetColorScale(ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1})
+		popup.turretName.SetColorScale(ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1})
 	}
 }
 

--- a/examples/autotanks/railgun_ray.go
+++ b/examples/autotanks/railgun_ray.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"github.com/quasilyte/ge"
+
 	"github.com/quasilyte/gmath"
 )
 
 type railgunRay struct {
-	from     gmath.Vec
-	to       gmath.Vec
-	line     *ge.Line
-	alpha    float64
-	disposed bool
+	from       gmath.Vec
+	to         gmath.Vec
+	line       *ge.Line
+	colorScale ge.ColorScale
+	alpha      float64
+	disposed   bool
 }
 
 func newRailgunRay(from, to gmath.Vec) *railgunRay {
@@ -26,15 +28,17 @@ func (ray *railgunRay) Dispose() {
 }
 
 func (ray *railgunRay) Init(scene *ge.Scene) {
-	ray.line = ge.NewLine(&ray.from, &ray.to)
-	ray.line.ColorScale.SetRGBA(255, 100, 180, 255)
+	ray.line = ge.NewLine(ge.MakePos(ray.from), ge.MakePos(ray.to))
+	ray.colorScale = ge.ColorScale{R: 255, G: 100, B: 180, A: 255}
+	ray.line.SetColorScale(ray.colorScale)
 	ray.line.Width = 3
 	scene.AddGraphics(ray.line)
 }
 
 func (ray *railgunRay) Update(delta float64) {
-	ray.line.ColorScale.A -= float32(delta * 4)
-	if ray.line.ColorScale.A < 0.2 {
+	ray.colorScale.A -= float32(delta * 4)
+	ray.line.SetColorScale(ray.colorScale)
+	if ray.colorScale.A < 0.2 {
 		ray.Dispose()
 	}
 }

--- a/examples/autotanks/results_controller.go
+++ b/examples/autotanks/results_controller.go
@@ -6,14 +6,13 @@ import (
 	"strconv"
 
 	"github.com/quasilyte/ge"
-	"github.com/quasilyte/ge/input"
 )
 
 type resultsController struct {
 	scene     *ge.Scene
 	gameState *gameState
 	config    battleConfig
-	input     *input.MultiHandler
+	input     *MultiHandler
 	result    battleResult
 }
 
@@ -87,7 +86,7 @@ func (c *resultsController) Init(scene *ge.Scene) {
 		l.Pos.Offset.Y = y
 		l.AlignHorizontal = ge.AlignHorizontalCenter
 		l.Width = 256
-		l.ColorScale.SetColor(c)
+		l.SetColorScaleRGBA(c.R, c.G, c.B, c.A)
 		return l
 	}
 

--- a/examples/autotanks/teams.go
+++ b/examples/autotanks/teams.go
@@ -3,8 +3,9 @@ package main
 import (
 	"image/color"
 
-	"github.com/quasilyte/ge"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 func unitLayerMask(alliance int) uint16 {
@@ -31,10 +32,10 @@ func getPlayerTextColor(playerID int) color.RGBA {
 func applyPlayerColor(playerID int, s *ge.Sprite) {
 	switch playerID {
 	case 1:
-		s.SetHue(gmath.DegToRad(50))
+		SetHue(s, gmath.DegToRad(50))
 	case 2:
-		s.SetHue(-gmath.DegToRad(180))
+		SetHue(s, gmath.DegToRad(180))
 	case 3:
-		s.SetHue(gmath.DegToRad(135))
+		SetHue(s, gmath.DegToRad(135))
 	}
 }

--- a/examples/autotanks/tutorial_controller.go
+++ b/examples/autotanks/tutorial_controller.go
@@ -4,11 +4,10 @@ import (
 	"runtime"
 
 	"github.com/quasilyte/ge"
-	"github.com/quasilyte/ge/input"
 )
 
 type tutorialController struct {
-	input *input.MultiHandler
+	input *MultiHandler
 
 	scene *ge.Scene
 
@@ -50,7 +49,7 @@ func (c *tutorialController) Init(scene *ge.Scene) {
 	continueLabel.Text = continueText
 	continueLabel.GrowHorizontal = ge.GrowHorizontalBoth
 	continueLabel.AlignHorizontal = ge.AlignHorizontalCenter
-	continueLabel.ColorScale = ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1}
+	continueLabel.SetColorScale(ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1})
 	scene.AddGraphics(continueLabel)
 
 	contorolsText := scene.Dict().Get("tutorial.keymap.keyboard")
@@ -74,7 +73,7 @@ func (c *tutorialController) Init(scene *ge.Scene) {
 		warningLabel.Text = scene.Dict().Get("tutorial.wasm_notice")
 		warningLabel.Pos.Offset.X = 1024
 		warningLabel.Pos.Offset.Y = 256 + 32 + 450
-		warningLabel.ColorScale.SetRGBA(255, 180, 180, 255)
+		warningLabel.SetColorScaleRGBA(255, 180, 180, 255)
 		scene.AddGraphics(warningLabel)
 	}
 }

--- a/examples/autotanks/ui.go
+++ b/examples/autotanks/ui.go
@@ -3,9 +3,10 @@ package main
 import (
 	"strconv"
 
+	"github.com/quasilyte/gmath"
+
 	"github.com/quasilyte/ge"
 	"github.com/quasilyte/ge/xslices"
-	"github.com/quasilyte/gmath"
 )
 
 type focusToggler interface {
@@ -95,9 +96,9 @@ func (b *checkboxButton) Update(delta float64) {
 
 func (b *checkboxButton) updateColor() {
 	if b.Focused {
-		b.label.ColorScale = ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1}
+		b.label.SetColorScale(ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1})
 	} else {
-		b.label.ColorScale = ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1}
+		b.label.SetColorScale(ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1})
 	}
 }
 
@@ -153,9 +154,9 @@ func (b *selectButton) Update(delta float64) {
 
 func (b *selectButton) updateColor() {
 	if b.Focused {
-		b.label.ColorScale = ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1}
+		b.label.SetColorScale(ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1})
 	} else {
-		b.label.ColorScale = ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1}
+		b.label.SetColorScale(ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1})
 	}
 }
 
@@ -219,9 +220,9 @@ func (b *button) Update(delta float64) {
 
 func (b *button) updateColor() {
 	if b.Focused {
-		b.label.ColorScale = ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1}
+		b.label.SetColorScale(ge.ColorScale{R: 0.8, G: 1, B: 0.8, A: 1})
 	} else {
-		b.label.ColorScale = ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1}
+		b.label.SetColorScale(ge.ColorScale{R: 0.6, G: 0.6, B: 0.6, A: 1})
 	}
 }
 
@@ -295,8 +296,8 @@ func (d *priceDisplay) SetAvailable(iron, gold, oil bool) {
 
 func (d *priceDisplay) setAvailable(l *ge.Label, available bool) {
 	if available {
-		l.ColorScale.SetRGBA(255, 255, 255, 255)
+		l.SetColorScaleRGBA(255, 255, 255, 255)
 	} else {
-		l.ColorScale.SetRGBA(255, 180, 180, 255)
+		l.SetColorScaleRGBA(255, 180, 180, 255)
 	}
 }

--- a/examples/autotanks/unitstats_controller.go
+++ b/examples/autotanks/unitstats_controller.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/quasilyte/ge"
-	"github.com/quasilyte/ge/input"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 type unitStatsController struct {
 	scene     *ge.Scene
-	input     *input.MultiHandler
+	input     *MultiHandler
 	gameState *gameState
 }
 
@@ -44,7 +44,8 @@ func (c *unitStatsController) Init(scene *ge.Scene) {
 			scene.AddGraphics(imageBg)
 
 			image := scene.NewSprite(d.Image)
-			image.Scale = 1.5
+			w, h := image.GetScale()
+			image.SetScale(w*1.5, h*1.5)
 			image.Pos.SetBase(pos.Sub(gmath.Vec{X: 8}))
 			scene.AddGraphics(image)
 
@@ -87,7 +88,8 @@ func (c *unitStatsController) Init(scene *ge.Scene) {
 			scene.AddGraphics(imageBg)
 
 			image := scene.NewSprite(d.Image)
-			image.Scale = 1.5
+			w, h := image.GetScale()
+			image.SetScale(w*1.5, h*1.5)
 			image.Pos.SetBase(pos.Sub(gmath.Vec{X: 4}))
 			scene.AddGraphics(image)
 

--- a/examples/tankarcade/battle_base.go
+++ b/examples/tankarcade/battle_base.go
@@ -3,10 +3,11 @@ package main
 import (
 	"fmt"
 
+	"github.com/quasilyte/gmath"
+
 	"github.com/quasilyte/ge"
 	"github.com/quasilyte/ge/gesignal"
 	"github.com/quasilyte/ge/physics"
-	"github.com/quasilyte/gmath"
 )
 
 type battleBase struct {
@@ -49,7 +50,7 @@ func (b *battleBase) Init(scene *ge.Scene) {
 	scene.AddBody(&b.Body)
 
 	b.sprite = scene.NewSprite(ImageBase)
-	b.sprite.SetHue(spriteHue(b.alliance))
+	SetHue(b.sprite, spriteHue(b.alliance))
 	b.sprite.Pos.Base = &b.Body.Pos
 	b.sprite.Shader = scene.NewShader(ShaderBuildingDamage)
 	b.sprite.Shader.SetFloatValue("HP", 1.0)

--- a/examples/tankarcade/battle_bonus_generator.go
+++ b/examples/tankarcade/battle_bonus_generator.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"github.com/quasilyte/gmath"
+
 	"github.com/quasilyte/ge"
 	"github.com/quasilyte/ge/gesignal"
 	"github.com/quasilyte/ge/physics"
-	"github.com/quasilyte/gmath"
 )
 
 type battleBonusGenerator struct {
@@ -50,7 +51,7 @@ func (b *battleBonusGenerator) Init(scene *ge.Scene) {
 	scene.AddBody(&b.Body)
 
 	b.sprite = scene.NewSprite(ImageBonusGenerator)
-	b.sprite.SetHue(spriteHue(b.alliance))
+	SetHue(b.sprite, spriteHue(b.alliance))
 	b.sprite.Pos.Base = &b.Body.Pos
 	b.sprite.Rotation = &b.Body.Rotation
 	b.sprite.Shader = scene.NewShader(ShaderBuildingDamage)

--- a/examples/tankarcade/battle_factory.go
+++ b/examples/tankarcade/battle_factory.go
@@ -3,10 +3,11 @@ package main
 import (
 	"fmt"
 
+	"github.com/quasilyte/gmath"
+
 	"github.com/quasilyte/ge"
 	"github.com/quasilyte/ge/gesignal"
 	"github.com/quasilyte/ge/physics"
-	"github.com/quasilyte/gmath"
 )
 
 type battleFactory struct {
@@ -76,7 +77,7 @@ func (b *battleFactory) Init(scene *ge.Scene) {
 	scene.AddBody(&b.Body)
 
 	b.sprite = scene.NewSprite(ImageFactory)
-	b.sprite.SetHue(spriteHue(b.alliance))
+	SetHue(b.sprite, spriteHue(b.alliance))
 	b.sprite.Pos.Base = &b.Body.Pos
 	b.sprite.Rotation = &b.Body.Rotation
 	b.sprite.Shader = scene.NewShader(ShaderBuildingDamage)

--- a/examples/tankarcade/battle_fort.go
+++ b/examples/tankarcade/battle_fort.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"github.com/quasilyte/gmath"
+
 	"github.com/quasilyte/ge"
 	"github.com/quasilyte/ge/gesignal"
 	"github.com/quasilyte/ge/physics"
-	"github.com/quasilyte/gmath"
 )
 
 type battleFort struct {
@@ -52,7 +53,7 @@ func (b *battleFort) Init(scene *ge.Scene) {
 	scene.AddBody(&b.Body)
 
 	b.sprite = scene.NewSprite(ImageWall)
-	b.sprite.SetHue(spriteHue(b.alliance))
+	SetHue(b.sprite, spriteHue(b.alliance))
 	b.sprite.Pos.Base = &b.Body.Pos
 	scene.AddGraphics(b.sprite)
 
@@ -61,7 +62,7 @@ func (b *battleFort) Init(scene *ge.Scene) {
 		turretImage = ImageTurret2
 	}
 	b.turretSprite = scene.NewSprite(turretImage)
-	b.turretSprite.SetHue(spriteHue(b.alliance))
+	SetHue(b.turretSprite, spriteHue(b.alliance))
 	b.turretSprite.Pos.Base = &b.Body.Pos
 	b.turretSprite.Rotation = &b.Body.Rotation
 	b.turretSprite.Shader = scene.NewShader(ShaderBuildingDamage)

--- a/examples/tankarcade/battle_mine.go
+++ b/examples/tankarcade/battle_mine.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"github.com/quasilyte/gmath"
+
 	"github.com/quasilyte/ge"
 	"github.com/quasilyte/ge/physics"
-	"github.com/quasilyte/gmath"
 )
 
 type battleMine struct {
@@ -25,7 +26,7 @@ func (b *battleMine) Init(scene *ge.Scene) {
 
 	b.sprite = scene.NewSprite(ImageMine)
 	b.sprite.Pos.Base = &b.body.Pos
-	b.sprite.SetHue(spriteHue(b.alliance))
+	SetHue(b.sprite, spriteHue(b.alliance))
 	scene.AddGraphicsBelow(b.sprite, 1)
 
 	b.body.InitStaticCircle(b, 8)

--- a/examples/tankarcade/battle_panel.go
+++ b/examples/tankarcade/battle_panel.go
@@ -38,14 +38,24 @@ func (p *battlePanel) Init(scene *ge.Scene) {
 			}
 			l := scene.NewLabel(FontSmall)
 			l.Text = fmt.Sprintf("Player %d |", i+1)
-			l.ColorScale.SetColor(ge.RGB(0xe42cca))
+			l.SetColorScaleRGBA(
+				ge.RGB(0xe42cca).R,
+				ge.RGB(0xe42cca).G,
+				ge.RGB(0xe42cca).B,
+				ge.RGB(0xe42cca).A,
+			)
 			l.Pos.Offset.Y = 896 + 32 + offset
 			l.Pos.Offset.X = 64
 			scene.AddGraphicsAbove(l, 1)
 
 			value := scene.NewLabel(FontSmall)
 			value.Text = "HP: ?"
-			value.ColorScale.SetColor(ge.RGB(0xe42cca))
+			value.SetColorScaleRGBA(
+				ge.RGB(0xe42cca).R,
+				ge.RGB(0xe42cca).G,
+				ge.RGB(0xe42cca).B,
+				ge.RGB(0xe42cca).A,
+			)
 			value.Pos.Offset.Y = 896 + 32 + offset
 			value.Pos.Offset.X = 64 + 288
 			scene.AddGraphicsAbove(value, 1)
@@ -53,7 +63,12 @@ func (p *battlePanel) Init(scene *ge.Scene) {
 
 			specialLabel := scene.NewLabel(FontSmall)
 			specialLabel.Text = "Special: ?"
-			specialLabel.ColorScale.SetColor(ge.RGB(0xe42cca))
+			specialLabel.SetColorScaleRGBA(
+				ge.RGB(0xe42cca).R,
+				ge.RGB(0xe42cca).G,
+				ge.RGB(0xe42cca).B,
+				ge.RGB(0xe42cca).A,
+			)
 			specialLabel.Pos.Offset.Y = 896 + 32 + offset
 			specialLabel.Pos.Offset.X = 64 + 288 + 224
 			scene.AddGraphicsAbove(specialLabel, 1)

--- a/examples/tankarcade/battle_unit.go
+++ b/examples/tankarcade/battle_unit.go
@@ -4,10 +4,11 @@ import (
 	"math"
 
 	resource "github.com/quasilyte/ebitengine-resource"
+	"github.com/quasilyte/gmath"
+
 	"github.com/quasilyte/ge"
 	"github.com/quasilyte/ge/gesignal"
 	"github.com/quasilyte/ge/physics"
-	"github.com/quasilyte/gmath"
 )
 
 var facingAngles = []gmath.Rad{
@@ -110,7 +111,7 @@ func (u *battleUnit) Init(scene *ge.Scene) {
 	scene.AddBody(&u.Body)
 
 	u.sprite = scene.NewSprite(u.config.image)
-	u.sprite.SetHue(spriteHue(u.config.alliance))
+	SetHue(u.sprite, spriteHue(u.config.alliance))
 	u.sprite.Pos.Base = &u.Body.Pos
 	u.sprite.Rotation = &u.Body.Rotation
 	scene.AddGraphics(u.sprite)

--- a/examples/tankarcade/battle_wall.go
+++ b/examples/tankarcade/battle_wall.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"github.com/quasilyte/gmath"
+
 	"github.com/quasilyte/ge"
 	"github.com/quasilyte/ge/gesignal"
 	"github.com/quasilyte/ge/physics"
-	"github.com/quasilyte/gmath"
 )
 
 type battleWall struct {
@@ -41,7 +42,7 @@ func (b *battleWall) Init(scene *ge.Scene) {
 	scene.AddBody(&b.Body)
 
 	b.sprite = scene.NewSprite(ImageWall)
-	b.sprite.SetHue(spriteHue(b.alliance))
+	SetHue(b.sprite, spriteHue(b.alliance))
 	b.sprite.Pos.Base = &b.Body.Pos
 	b.sprite.Shader = scene.NewShader(ShaderBuildingDamage)
 	b.sprite.Shader.SetFloatValue("HP", 1.0)

--- a/examples/tankarcade/colorutil.go
+++ b/examples/tankarcade/colorutil.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"image/color"
+	"math"
+
+	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
+)
+
+func rgbaToHSL(c ge.ColorScale) (h, s, l gmath.Rad) {
+	r := float64(c.R)
+	g := float64(c.G)
+	b := float64(c.B)
+	maxVal := math.Max(math.Max(r, g), b)
+	minVal := math.Min(math.Min(r, g), b)
+	l = gmath.Rad((maxVal + minVal) / 2)
+
+	if maxVal == minVal {
+		h = 0
+		s = 0
+		return
+	}
+
+	d := maxVal - minVal
+	if l > 0.5 {
+		s = gmath.Rad(d / (2 - maxVal - minVal))
+	} else {
+		s = gmath.Rad(d / (maxVal + minVal))
+	}
+	switch maxVal {
+	case r:
+		h = gmath.Rad((g - b) / d)
+		if g < b {
+			h += 6
+		}
+	case g:
+		h = gmath.Rad((b-r)/d + 2)
+	case b:
+		h = gmath.Rad((r-g)/d + 4)
+	}
+	h /= 6
+
+	return
+}
+
+func hslToRGBA(h, s, l gmath.Rad) color.RGBA {
+	var r, g, b gmath.Rad
+	if s == 0 {
+		r, g, b = l, l, l // achromatic
+		return color.RGBA{R: uint8(r * 255), G: uint8(g * 255), B: uint8(b * 255), A: 255}
+	}
+
+	var q gmath.Rad
+	if l < 0.5 {
+		q = l * (1 + s)
+	} else {
+		q = l + s - l*s
+	}
+	p := 2*l - q
+	r = hueToRGB(p, q, h+1/3)
+	g = hueToRGB(p, q, h)
+	b = hueToRGB(p, q, h-1/3)
+
+	return color.RGBA{R: uint8(r * 255), G: uint8(g * 255), B: uint8(b * 255), A: 255}
+}
+
+func hueToRGB(p, q, t gmath.Rad) gmath.Rad {
+	if t < 0 {
+		t += 1
+	}
+	if t > 1 {
+		t -= 1
+	}
+	if t < 1/6 {
+		return p + (q-p)*6*t
+	}
+	if t < 1/2 {
+		return q
+	}
+	if t < 2/3 {
+		return p + (q-p)*(2/3-t)*6
+	}
+	return p
+}
+
+func SetHue(s *ge.Sprite, nh gmath.Rad) {
+	rgba := s.GetColorScale()
+	_, oldSat, oldLum := rgbaToHSL(rgba)
+	nr, ng, nb, _ := hslToRGBA(nh, oldSat, oldLum).RGBA()
+	s.SetColorScaleRGBA(uint8(nr), uint8(ng), uint8(nb), 255)
+}

--- a/examples/tankarcade/explosion.go
+++ b/examples/tankarcade/explosion.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	resource "github.com/quasilyte/ebitengine-resource"
-	"github.com/quasilyte/ge"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 type explosion struct {
@@ -31,7 +32,7 @@ func (e *explosion) Init(scene *ge.Scene) {
 	e.rotation = scene.Rand().Rad()
 	sprite := scene.NewSprite(e.Image)
 	sprite.Pos.Base = &e.pos
-	sprite.SetHue(e.Hue)
+	SetHue(sprite, e.Hue)
 	sprite.SetScale(e.Scale, e.Scale)
 
 	sprite.Rotation = &e.rotation

--- a/examples/tankarcade/level_transition_controller.go
+++ b/examples/tankarcade/level_transition_controller.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/quasilyte/ge"
 	"github.com/quasilyte/gmath"
+
+	"github.com/quasilyte/ge"
 )
 
 type levelTransitionController struct {
@@ -35,7 +36,12 @@ func (c *levelTransitionController) Init(scene *ge.Scene) {
 		}
 	}
 	title.Pos.Offset = scene.Context().WindowRect().Center().Add(gmath.Vec{X: -480, Y: -80})
-	title.ColorScale.SetColor(ge.RGB(0xe42cca))
+	title.SetColorScaleRGBA(
+		ge.RGB(0xe42cca).R,
+		ge.RGB(0xe42cca).G,
+		ge.RGB(0xe42cca).B,
+		ge.RGB(0xe42cca).A,
+	)
 	title.Width = 960
 	title.AlignHorizontal = ge.AlignHorizontalCenter
 	scene.AddGraphics(title)
@@ -47,7 +53,12 @@ func (c *levelTransitionController) Init(scene *ge.Scene) {
 		action1.Text = "Press " + formattedActionString(h, ActionConfirm) + " To Continue"
 	}
 	action1.Pos.Offset = scene.Context().WindowRect().Center().Add(gmath.Vec{X: -320})
-	action1.ColorScale.SetColor(ge.RGB(0xe42cca))
+	action1.SetColorScaleRGBA(
+		ge.RGB(0xe42cca).R,
+		ge.RGB(0xe42cca).G,
+		ge.RGB(0xe42cca).B,
+		ge.RGB(0xe42cca).A,
+	)
 	action1.Width = 640
 	action1.AlignHorizontal = ge.AlignHorizontalCenter
 	scene.AddGraphics(action1)
@@ -56,7 +67,12 @@ func (c *levelTransitionController) Init(scene *ge.Scene) {
 		action2 := scene.NewLabel(FontSmall)
 		action2.Text = "Press " + formattedActionString(h, ActionEscape) + " To Exit"
 		action2.Pos.Offset = scene.Context().WindowRect().Center().Add(gmath.Vec{X: -320, Y: 40})
-		action2.ColorScale.SetColor(ge.RGB(0xe42cca))
+		action2.SetColorScaleRGBA(
+			ge.RGB(0xe42cca).R,
+			ge.RGB(0xe42cca).G,
+			ge.RGB(0xe42cca).B,
+			ge.RGB(0xe42cca).A,
+		)
 		action2.Width = 640
 		action2.AlignHorizontal = ge.AlignHorizontalCenter
 		scene.AddGraphics(action2)

--- a/ui/button.go
+++ b/ui/button.go
@@ -100,7 +100,7 @@ func (b *Button) Init(scene *ge.Scene) {
 	b.label.AlignHorizontal = ge.AlignHorizontalCenter
 	b.label.AlignVertical = ge.AlignVerticalCenter
 	b.label.Pos = b.Pos
-	b.label.ColorScale = b.style.TextColor
+	b.label.SetColorScale(b.style.TextColor)
 	b.label.Visible = b.Visible
 	scene.AddGraphics(b.label)
 }
@@ -121,11 +121,11 @@ func (b *Button) SetDisabled(disabled bool) {
 	b.disabled = disabled
 	if b.disabled {
 		b.SetFocus(false)
-		b.label.ColorScale = b.style.DisabledTextColor
+		b.label.SetColorScale(b.style.DisabledTextColor)
 		b.rect.FillColorScale = b.style.DisabledBackgroundColor
 		b.rect.OutlineColorScale = b.style.DisabledBorderColor
 	} else {
-		b.label.ColorScale = b.style.TextColor
+		b.label.SetColorScale(b.style.TextColor)
 		b.rect.FillColorScale = b.style.BackgroundColor
 		b.rect.OutlineColorScale = b.style.BorderColor
 	}
@@ -133,11 +133,11 @@ func (b *Button) SetDisabled(disabled bool) {
 
 func (b *Button) onFocusChanged(focused bool) {
 	if focused {
-		b.label.ColorScale = b.style.FocusedTextColor
+		b.label.SetColorScale(b.style.FocusedTextColor)
 		b.rect.FillColorScale = b.style.FocusedBackgroundColor
 		b.rect.OutlineColorScale = b.style.FocusedBorderColor
 	} else {
-		b.label.ColorScale = b.style.TextColor
+		b.label.SetColorScale(b.style.TextColor)
 		b.rect.FillColorScale = b.style.BackgroundColor
 		b.rect.OutlineColorScale = b.style.BorderColor
 	}

--- a/ui/value_label.go
+++ b/ui/value_label.go
@@ -89,7 +89,7 @@ func (l *ValueLabel[T]) Init(scene *ge.Scene) {
 	l.label.AlignHorizontal = ge.AlignHorizontalCenter
 	l.label.AlignVertical = ge.AlignVerticalCenter
 	l.label.Pos = l.Pos
-	l.label.ColorScale = l.style.TextColor
+	l.label.SetColorScale(l.style.TextColor)
 	scene.AddGraphics(l.label)
 
 	if l.value != nil {


### PR DESCRIPTION
Please double check that this is acceptable, the tank examples do build now and play fine. ¯\\_(ツ)_/¯

Note: it does seem like `*ge.Line` is missing a `GetColorScale` method, and so what I did for the railgun is a bit of a hack to compensate for that. If someone confirms for me it should have that method I can make a separate PR for that.